### PR TITLE
fix: LenraFlex Spacing after baseSize rework

### DIFF
--- a/lib/views/activation_code_page.dart
+++ b/lib/views/activation_code_page.dart
@@ -33,14 +33,14 @@ class _ActivationCodePageState extends State<ActivationCodePage> {
       child: LenraFlex(
         direction: Axis.vertical,
         crossAxisAlignment: CrossAxisAlignment.center,
-        spacing: 4,
+        spacing: 32,
         children: [
           LenraFlex(
             direction: Axis.vertical,
-            spacing: 2,
+            spacing: 16,
             children: [
               LenraFlex(
-                spacing: 2,
+                spacing: 16,
                 fillParent: true,
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [

--- a/lib/views/create_project_form.dart
+++ b/lib/views/create_project_form.dart
@@ -28,7 +28,7 @@ class _CreateProjectFormState extends State<CreateProjectForm> {
       key: _formKey,
       child: LenraFlex(
         direction: Axis.vertical,
-        spacing: 4,
+        spacing: 32,
         crossAxisAlignment: CrossAxisAlignment.end,
         children: [
           fields(context),
@@ -47,7 +47,7 @@ class _CreateProjectFormState extends State<CreateProjectForm> {
   Widget fields(BuildContext context) {
     return LenraFlex(
       direction: Axis.vertical,
-      spacing: 2,
+      spacing: 16,
       children: [
         LenraTextFormField(
           validator: validator([

--- a/lib/views/overview_page.dart
+++ b/lib/views/overview_page.dart
@@ -68,7 +68,7 @@ class _OverviewPageState extends State<OverviewPage> {
       ),
       child: LenraFlex(
         direction: Axis.vertical,
-        spacing: 2,
+        spacing: 16,
         children: [
           Row(
             mainAxisAlignment: MainAxisAlignment.end,
@@ -161,7 +161,7 @@ class _OverviewPageState extends State<OverviewPage> {
       LenraTableCell(
         child: LenraFlex(
           crossAxisAlignment: CrossAxisAlignment.center,
-          spacing: 1,
+          spacing: 8,
           children: [
             Icon(
               Icons.circle,

--- a/lib/views/settings/git_integration_menu.dart
+++ b/lib/views/settings/git_integration_menu.dart
@@ -43,7 +43,7 @@ class _GitIntegrationMenuState extends State<GitIntegrationMenu> {
       key: _formKey,
       child: LenraFlex(
         direction: Axis.vertical,
-        spacing: 1,
+        spacing: 8,
         children: [
           LenraText(
             text: "Git integration",
@@ -62,7 +62,7 @@ class _GitIntegrationMenuState extends State<GitIntegrationMenu> {
                 style: lenraTextThemeData.bodyText,
               ),
               LenraFlex(
-                spacing: 1,
+                spacing: 8,
                 children: [
                   Expanded(
                     child: LenraTextFormField(
@@ -97,7 +97,7 @@ class _GitIntegrationMenuState extends State<GitIntegrationMenu> {
                 style: lenraTextThemeData.bodyText,
               ),
               LenraFlex(
-                spacing: 1,
+                spacing: 8,
                 children: [
                   Expanded(
                     child: LenraTextFormField(

--- a/lib/views/settings/manage_access_menu.dart
+++ b/lib/views/settings/manage_access_menu.dart
@@ -55,7 +55,7 @@ class _ManageAccessMenuState extends State<ManageAccessMenu> {
 
     return isInitialized
         ? LenraFlex(
-            spacing: 1,
+            spacing: 8,
             direction: Axis.vertical,
             children: [
               Text("Manage access", style: lenraTextThemeData.headline3),
@@ -106,7 +106,7 @@ class _ManageAccessMenuState extends State<ManageAccessMenu> {
               ),
               ...invitedUsers.map((user) {
                 return LenraFlex(
-                  spacing: 1,
+                  spacing: 8,
                   crossAxisAlignment: CrossAxisAlignment.center,
                   mainAxisAlignment: MainAxisAlignment.spaceAround,
                   children: [

--- a/lib/views/settings_page.dart
+++ b/lib/views/settings_page.dart
@@ -30,12 +30,12 @@ class _SettingsPageState extends State<SettingsPage> {
         onPressed: () {},
       ),
       child: LenraFlex(
-        spacing: 2,
+        spacing: 16,
         children: [
           LenraContainer(
             constraints: BoxConstraints(maxWidth: 200),
             child: LenraFlex(
-              spacing: 2,
+              spacing: 16,
               direction: Axis.vertical,
               children: [
                 createSubMenuItem("Git integration", callback: () {

--- a/lib/views/side_menu.dart
+++ b/lib/views/side_menu.dart
@@ -138,7 +138,7 @@ class _ProjectMenuState extends State<_ProjectMenu> {
           child: isInitialized
               ? LenraFlex(
                   direction: Axis.vertical,
-                  spacing: 0.5,
+                  spacing: 4,
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
@@ -147,7 +147,7 @@ class _ProjectMenuState extends State<_ProjectMenu> {
                     ),
                     LenraFlex(
                       crossAxisAlignment: CrossAxisAlignment.center,
-                      spacing: 1,
+                      spacing: 8,
                       children: [
                         Icon(
                           Icons.circle,


### PR DESCRIPTION
## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I included unit tests that cover my changes
- [x] I added/updated the documentation about my changes
- [x] I made my own code-review before requesting one

## Description of the changes
<!-- 
    Simple description of what changed ?
    This helps the reviewer to understand what happens in your code changes and why.
-->

We change the way we handle the `baseSize`. So now instead of using the `baseSize` for the spacing, we use the default system as in Flutter. Each value is multiplied by 8 which was the value of the `baseSize`.

