### PR TITLE
fix: Overview page refresh every 5 seconds

### DIFF
--- a/lib/views/overview_page.dart
+++ b/lib/views/overview_page.dart
@@ -76,7 +76,9 @@ class _OverviewPageState extends State<OverviewPage> {
 
       if (hasPendingBuild) {
         timer = Timer(Duration(seconds: 5), () {
-          setState(() {});
+          buildModel.fetchBuilds(widget.appId).then((_) {
+            setState(() {});
+          });
         });
       }
 
@@ -89,7 +91,9 @@ class _OverviewPageState extends State<OverviewPage> {
       actionWidget: LenraButton(
         text: "Publish my application",
         disabled: hasPendingBuild,
-        onPressed: () => buildModel.createBuild(app!.id),
+        onPressed: () => buildModel.createBuild(app!.id).then((_) {
+          setState(() {});
+        }),
       ),
       child: buildPage(context, hasPublishedBuild, builds),
     );


### PR DESCRIPTION
<!-- 
Link the related issue :
#42
-->
Closes https://github.com/lenra-io/client-backoffice/issues/65

## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I included unit tests that cover my changes
- [x] I added/updated the documentation about my changes
- [x] I made my own code-review before requesting one

## Description of the changes
<!-- 
    Simple description of what changed ?
    This helps the reviewer to understand what happens in your code changes and why.
-->

The Overview page was not refreshed anymore because a PR move the code fetching the builds to the initState, causing it to not be executed again when the timer triggered a setState.
